### PR TITLE
Check logging

### DIFF
--- a/scoring/db.py
+++ b/scoring/db.py
@@ -113,6 +113,7 @@ def reset_all_tables():
     reset_table('pcr')
     reset_table('default_creds_log')
     reset_table('revert_log')
+    reset_table('check_log')
 
 def insert(table, columns, args):
     """

--- a/scoring/engine/model.py
+++ b/scoring/engine/model.py
@@ -308,18 +308,20 @@ class Result(object):
         check (Check): The check this result resulted from
         check_io (CheckIO): The input-output pair used in the check
         team (Team): The team this result is for
+        check_round (int): The check round this result belongs to
         poll_input (PollInput): The specific poller input used in the check
         poll_result (PollResult): The specific poller output retrieved from
             the poller
         result (bool): The result of the check
     """
     
-    def __init__(self, id, check, check_io, team, 
+    def __init__(self, id, check, check_io, team, check_round,
                  time, poll_input, poll_result, result):
         self.id = int(id)
         self.check = check
         self.check_io = check_io
         self.team = team
+        self.check_round = check_round
         self.time = time
         self.poll_input = poll_input
         self.poll_result = poll_result

--- a/scoring/schema.sql
+++ b/scoring/schema.sql
@@ -85,12 +85,18 @@ CREATE TABLE `cred_input` (
     FOREIGN KEY (`check_io_id`) REFERENCES `check_io`(`id`)
        ON DELETE CASCADE);
 
+DROP TABLE IF EXISTS `check_log`;
+CREATE TABLE `check_log` (
+    `check_round` INT PRIMARY KEY AUTO_INCREMENT,
+    `time` TIMESTAMP DEFAULT CURRENT_TIMESTAMP);
+
 DROP TABLE IF EXISTS `result`;
 CREATE TABLE `result` (
     `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     `check_id` INT NOT NULL,
     `check_io_id` INT NOT NULL,
     `team_id` INT NOT NULL,
+    `check_round` INT NOT NULL,
     `time` TIMESTAMP NOT NULL,
     `poll_input` VARCHAR(4095) NOT NULL,
     `poll_result` VARCHAR(4095) NOT NULL,
@@ -100,6 +106,8 @@ CREATE TABLE `result` (
     FOREIGN KEY (`check_io_id`) REFERENCES `check_io`(`id`)
        ON DELETE CASCADE,
     FOREIGN KEY (`team_id`) REFERENCES `team`(`id`)
+       ON DELETE CASCADE,
+    FOREIGN KEY (`check_round`) REFERENCES `check_log`(`check_round`)
        ON DELETE CASCADE);
 
 DROP TABLE IF EXISTS `pcr`;

--- a/scoring/start_engine.py
+++ b/scoring/start_engine.py
@@ -40,11 +40,13 @@ class ScoringEngine(object):
     def check(self):
         print("New Round of Checks")
         self.em.reload_credentials()
+
+        check_round = db.execute('INSERT INTO check_log () VALUES ()')
         for service in self.em.services:
             if self.team_num is None:
-                service.check(self.em.teams)
+                service.check(check_round, self.em.teams)
             else:
-                service.check([self.em.teams[self.team_num]])
+                service.check(check_round, [self.em.teams[self.team_num]])
 
     def log_default_creds(self):
         cmd = ('INSERT INTO default_creds_log (team_id, perc_default) '

--- a/scoring/web/server.py
+++ b/scoring/web/server.py
@@ -4,6 +4,7 @@ from .web_model import WebModel
 import flask
 from flask import Flask, render_template, request, redirect, url_for
 from urllib.parse import urlparse, urljoin
+import datetime
 from .forms import *
 from . import score
 import validate
@@ -268,6 +269,21 @@ def score():
     """
     Score information page
     """
+    start = request.args.get('start')
+    end = request.args.get('end')
+    today = datetime.datetime.today()
+    if start == '':
+        start = None
+    if end == '':
+        end = None
+    if not start is None:
+        start = datetime.datetime.strptime(start, '%H:%M')
+        start = start.replace(year=today.year, month=today.month, day=today.day)
+    if not end is None:
+        end = datetime.datetime.strptime(end, '%H:%M')
+        end = end.replace(year=today.year, month=today.month, day=today.day)
+
+    wm.load_results()
     results = wm.results
     simple_results = {}
     for team,tresults in results.items():
@@ -275,7 +291,9 @@ def score():
         for check,cresults in tresults.items():
             simple_results[team][check] = []
             for res in cresults:
-                simple_results[team][check].append([res.time.strftime('%Y-%m-%d %H:%M:%S'), res.result])
+                print(start, res.time)
+                if (start is None or res.time >= start) and (end is None or res.time <= end):
+                    simple_results[team][check].append([res.time.strftime('%Y-%m-%d %H:%M:%S'), res.result])
 
     teams = {}
     for team in wm.teams:

--- a/scoring/web/static/js/score.js
+++ b/scoring/web/static/js/score.js
@@ -247,7 +247,6 @@ function calc_scores(tids) {
             var score = 0;
         }
         var reset_penalty = document.getElementById("revert-" + tid).innerHTML;
-        console.log(reset_penalty)
         score_td.innerHTML = Math.round(score - reset_penalty);
     }
 }

--- a/scoring/web/templates/score.html
+++ b/scoring/web/templates/score.html
@@ -6,6 +6,25 @@
 <script type="text/javascript" src="/static/js/Chart.bundle-2.7.2.min.js"></script>
 <script src="/static/js/score.js"></script>
 
+<form action="{{ url_for('score') }}" method="GET" style="margin-top: 20px; margin-left:12.5%;">
+<label for="start">Start Time:</label>
+<input type="time" id="start-time" name="start"/>
+
+<label for="end">End Time:</label>
+<input type="time" id="end-time" name="end"/>
+<input type="submit" value="Set Time Range" class="btn btn-dark"/>
+</form>
+
+<script>
+    var si = document.getElementById('start-time');
+    var ei = document.getElementById('end-time');
+    params = new URLSearchParams(window.location.search);
+    start = params.get('start');
+    end = params.get('end');
+    si.value = start;
+    ei.value = end;
+</script>
+
 <select id="st-select" class="col-3 form-control" style="margin-top: 20px; margin-left:12.5%;" onchange="graph_dataset(this.value)">
     <option value="0" selected>All Teams</option>
     {% for id,team in teams.items() %}

--- a/scoring/web/web_model.py
+++ b/scoring/web/web_model.py
@@ -139,7 +139,7 @@ class WebModel(DataModel):
                       orderby='time ASC', args=(last_id))
 
         # Gather the results
-        for result_id, check_id, check_io_id, team_id, time, poll_input, poll_result, result in rows:
+        for result_id, check_id, check_io_id, team_id, check_round, time, poll_input, poll_result, result in rows:
             # Construct the result from the database info
             check = [c for c in self.checks if c.id == check_id][0]
             check_io = [cio for cio in self.check_ios if cio.id == check_io_id][0]
@@ -151,7 +151,7 @@ class WebModel(DataModel):
 
             poll_result = json.loads(poll_result)[1]
 
-            res = Result(result_id, check, check_io, team, time, poll_input, poll_result, result)
+            res = Result(result_id, check, check_io, team, check_round, time, poll_input, poll_result, result)
 
             self.results[team_id][check_id].append(res)
 


### PR DESCRIPTION
Better logging of check results. Improved score calculation.
- Records check start time and round # to database
- Associates round # to database
This will give us the ability to see how long a poller took to return, and more easily compare the results for sets of checks.

- Adds controls to the score page which limit the timeframe to score
This will give us the ability to tune the start and end times of the competition without having to directly manipulate the database.